### PR TITLE
Adds workflow for creating Jira ticket from PR

### DIFF
--- a/.github/workflows/create-jira-pr.yml
+++ b/.github/workflows/create-jira-pr.yml
@@ -29,7 +29,7 @@ jobs:
             -d '{
               "fields": {
                 "project": {
-                  "key": "PROJECTKEY"  # Replace with your Jira project key
+                  "key": "EX"  # Replace with your Jira project key
                 },
                 "summary": "'"$ISSUE_SUMMARY"'",
                 "description": "'"$ISSUE_DESCRIPTION"'",

--- a/.github/workflows/create-jira-pr.yml
+++ b/.github/workflows/create-jira-pr.yml
@@ -1,0 +1,41 @@
+name: Create Jira Ticket on PR
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  create-jira-ticket:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Create Jira Ticket
+        if: github.actor == 'duthied' && contains(github.event.pull_request.labels.*.name, 'severe')
+        env:
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_DOMAIN: ${{ secrets.JIRA_DOMAIN }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_URL="${{ github.event.pull_request.html_url }}"
+          ISSUE_SUMMARY="New PR created: $PR_TITLE"
+          ISSUE_DESCRIPTION="A new PR has been created by ${{ github.actor }}. \nPR Title: $PR_TITLE \nPR URL: $PR_URL"
+          
+          curl -X POST \
+            -u "${{ secrets.JIRA_USER_EMAIL }}:${{ secrets.JIRA_API_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "fields": {
+                "project": {
+                  "key": "PROJECTKEY"  # Replace with your Jira project key
+                },
+                "summary": "'"$ISSUE_SUMMARY"'",
+                "description": "'"$ISSUE_DESCRIPTION"'",
+                "issuetype": {
+                  "name": "Task"  # Replace with your desired issue type
+                }
+              }
+            }' \
+            "https://${{ secrets.JIRA_DOMAIN }}/rest/api/2/issue/"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically create a Jira ticket when a pull request is opened, the author is `duthied` and labeled as `severe`. Below are the key changes:

Workflow Creation:

* Added a new workflow file `.github/workflows/create-jira-pr.yml` to create a Jira ticket on PR creation.

  * The workflow triggers on pull request events of type `opened`.
  * It includes a job that runs on `ubuntu-latest` and checks out the code.
  * The job creates a Jira ticket if the pull request is opened by a specific user (`duthied`) and contains the label `severe`.
  * Jira API credentials and domain information are securely passed through GitHub secrets.
  * The Jira ticket includes the pull request title and URL in its summary and description.